### PR TITLE
build a universal pip module to allow python3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [metadata]
 description-file = README.md
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires = open(os.path.join(os.path.dirname(__file__), "requirements.txt")).read().split("\n"),
     classifiers = [
         'Programming Language :: Python :: 2',
-    #    'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3',
     ],
     packages=['cpe_utils'],
 )


### PR DESCRIPTION
This PR updates the build process to provide a universal package allowing this to be used with python3.

Tests pass using a python3 env in macOS and Ubuntu Linux 14.04 on Python 3.6.1.

Happy to add to this if more validation is desired for releasing a new pip module.

```
$ ./run_tests.sh
RUNNING TESTS
......part was false
vendor was false
product was false
version was false
update was false
edition was false
vendor was false
vendor was false
vendor was false
vendor was false
vendor was false
vendor was false
vendor was false
vendor was false
vendor was false
vendor was false
vendor was false
product was false
vendor was false
vendor was false
vendor was false
vendor was false
vendor was false
version was false
version was false
version was false
update was false
update was false
edition was false
edition was false
vendor was false
vendor was false
vendor was false
vendor was false
vendor was false
product was false
vendor was false
product was false
version was false
version was false
version was false
version was false
version was false
version was false
version was false
version was false
version was false
version was false
..
----------------------------------------------------------------------
Ran 8 tests in 0.009s

OK
```